### PR TITLE
[front] LoginPage layout 구현 완료

### DIFF
--- a/front/common/userContainer/Container.tsx
+++ b/front/common/userContainer/Container.tsx
@@ -23,6 +23,7 @@ function Container({ children }: UserContainerProps) {
           alt="wondering-pill-logo"
           layout="fill"
           objectFit="cover"
+          priority={true}
         />
       </LogoContainer>
       {children}

--- a/front/common/utils/constant.ts
+++ b/front/common/utils/constant.ts
@@ -1,6 +1,7 @@
 export const MAIN_COLOR = "#A8C0EA";
 export const SUB_COLOR = "#3C5A93";
 export const BUTTON_COLOR = "#9ADCDD";
+export const ERROR_MSG_COLOR = "#bd0000";
 
 export const ROUTE = {
   LOGIN: {

--- a/front/components/login/LoginForm.style.ts
+++ b/front/components/login/LoginForm.style.ts
@@ -31,10 +31,9 @@ export const Input = styled("input", {
 export const ErrorMessage = styled("div", (props: { $txtColor: string }) => ({
   textAlign: "start",
   width: "65%",
-  height: "1rem",
   padding: "0 1rem",
-  marginBottom: "0.5rem",
   color: props.$txtColor,
+  fontSize: "0.9rem",
 }));
 
 export const SubmitBtn = styled("button", (props: { $btnColor: string }) => ({

--- a/front/components/login/LoginForm.style.ts
+++ b/front/components/login/LoginForm.style.ts
@@ -6,6 +6,70 @@ export const Form = styled("form", {
   height: "40%",
 });
 
+export const ContentContainer = styled("div", {
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "space-between",
+  alignItems: "center",
+  height: "80%",
+});
+
+export const Input = styled("input", {
+  width: "65%",
+  height: "25%",
+  border: 0,
+  borderRadius: "25px",
+  fontSize: "1rem",
+  padding: "0 1rem",
+  "::-webkit-input-placeholder": {
+    textAlign: "center",
+    fontFamily: "'Noto Sans KR', sans-serif",
+    color: "#A4A4A4",
+  },
+});
+
+export const ErrorMessage = styled("div", (props: { $txtColor: string }) => ({
+  textAlign: "start",
+  width: "65%",
+  height: "1rem",
+  padding: "0 1rem",
+  marginBottom: "0.5rem",
+  color: props.$txtColor,
+}));
+
+export const SubmitBtn = styled("button", (props: { $btnColor: string }) => ({
+  width: "65%",
+  height: "25%",
+  border: 0,
+  borderRadius: "25px",
+  fontSize: "1rem",
+  backgroundColor: props.$btnColor,
+  color: "#fff",
+  fontWeight: "bold",
+}));
+
+export const SubBtnContainer = styled("div", {
+  display: "flex",
+  justifyContent: "space-evenly",
+  alignItems: "center",
+  width: "80%",
+  height: "20%",
+  margin: "0 auto",
+  color: "#fff",
+});
+
+export const CheckboxContainer = styled("div", {
+  color: "#fff",
+  fontSize: "0.9rem",
+});
+
+export const TextBtn = styled("button", {
+  border: 0,
+  backgroundColor: "transparent",
+  color: "#fff",
+  fontSize: "0.9rem",
+});
+
 export const SnsLoginContainer = styled("div", {
   height: "15%",
 });
@@ -20,7 +84,7 @@ export const SnsTitle = styled("div", {
     content: "''",
     flexGrow: 1,
     backgroundColor: "#fff",
-    height: "1.5px",
+    height: "1px",
     fontSize: "0px",
     lineHeight: "0px",
     margin: "0 1.5rem",
@@ -29,7 +93,7 @@ export const SnsTitle = styled("div", {
     content: "''",
     flexGrow: 1,
     backgroundColor: "#fff",
-    height: "1.5px",
+    height: "1px",
     fontSize: "0px",
     lineHeight: "0px",
     margin: "0 1.5rem",

--- a/front/components/login/LoginForm.tsx
+++ b/front/components/login/LoginForm.tsx
@@ -1,9 +1,12 @@
 import Image from "next/image";
-import { BUTTON_COLOR } from "@utils/constant";
+import { useFormik } from "formik";
+import * as Yup from "yup";
+import { BUTTON_COLOR, ERROR_MSG_COLOR } from "@utils/constant";
 import {
   Form,
   ContentContainer,
   Input,
+  ErrorMessage,
   SubmitBtn,
   SubBtnContainer,
   CheckboxContainer,
@@ -15,18 +18,63 @@ import {
   GoogleBtn,
 } from "./LoginForm.style";
 
+interface LoginValues {
+  email: string;
+  password: string;
+}
+
+const initialValue: LoginValues = { email: "", password: "" };
+
 function LoginForm() {
+  const formik = useFormik({
+    initialValues: initialValue,
+    validationSchema: Yup.object({
+      email: Yup.string()
+        .email("이메일을 다시 확인해 주세요.")
+        .required("이메일을 입력해 주세요."),
+      password: Yup.string()
+        .matches(
+          /^(?=.*[a-z])(?=.*\d)(?=.*[!@#\$%\^&\*])(?=.{8,})/,
+          "비밀번호는 소문자, 숫자, 특수문자 포함 8자 이상입니다.",
+        )
+        .required("비밀번호를 입력해 주세요."),
+    }),
+    onSubmit: async (values, actions) => {
+      // Submit Handler 구현 예정
+      console.log(values);
+    },
+  });
+
   return (
     <>
-      <Form>
+      <Form onSubmit={formik.handleSubmit}>
         <ContentContainer>
-          <Input id="email" name="email" type="text" placeholder="이메일" />
+          <Input
+            id="email"
+            name="email"
+            type="text"
+            placeholder="이메일"
+            onChange={formik.handleChange}
+            onBlur={formik.handleBlur}
+            value={formik.values.email}
+          />
+          <ErrorMessage $txtColor={ERROR_MSG_COLOR}>
+            {formik.touched.email && formik.errors.email}
+          </ErrorMessage>
+
           <Input
             id="password"
             name="password"
             type="password"
             placeholder="비밀번호"
+            onChange={formik.handleChange}
+            onBlur={formik.handleBlur}
+            value={formik.values.password}
           />
+          <ErrorMessage $txtColor={ERROR_MSG_COLOR}>
+            {formik.touched.password && formik.errors.password}
+          </ErrorMessage>
+
           <SubmitBtn $btnColor={BUTTON_COLOR}>로그인하기</SubmitBtn>
         </ContentContainer>
         <SubBtnContainer>

--- a/front/components/login/LoginForm.tsx
+++ b/front/components/login/LoginForm.tsx
@@ -1,6 +1,13 @@
 import Image from "next/image";
+import { BUTTON_COLOR } from "@utils/constant";
 import {
   Form,
+  ContentContainer,
+  Input,
+  SubmitBtn,
+  SubBtnContainer,
+  CheckboxContainer,
+  TextBtn,
   SnsLoginContainer,
   SnsTitle,
   SnsBtnContainer,
@@ -11,7 +18,27 @@ import {
 function LoginForm() {
   return (
     <>
-      <Form>LoginForm</Form>
+      <Form>
+        <ContentContainer>
+          <Input id="email" name="email" type="text" placeholder="이메일" />
+          <Input
+            id="password"
+            name="password"
+            type="password"
+            placeholder="비밀번호"
+          />
+          <SubmitBtn $btnColor={BUTTON_COLOR}>로그인하기</SubmitBtn>
+        </ContentContainer>
+        <SubBtnContainer>
+          <CheckboxContainer>
+            <input type="checkbox" name="auto-login" id="auto-login" />
+            <label htmlFor="auto-login">자동 로그인</label>
+          </CheckboxContainer>
+          <div>
+            <TextBtn>계정 찾기</TextBtn>/<TextBtn>비밀번호 찾기</TextBtn>
+          </div>
+        </SubBtnContainer>
+      </Form>
 
       <SnsLoginContainer>
         <SnsTitle>간편로그인</SnsTitle>

--- a/front/pages/_document.tsx
+++ b/front/pages/_document.tsx
@@ -126,6 +126,14 @@ class MyDocument extends NextDocument<{
             property="og:image"
             content="http://localhost:3000/icons/icon-48x48.png"
           />
+
+          {/* font */}
+          <link rel="preconnect" href="https://fonts.googleapis.com" />
+          <link rel="preconnect" href="https://fonts.gstatic.com" />
+          <link
+            href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR&display=swap"
+            rel="stylesheet"
+          />
         </Head>
         <body>
           <Main />

--- a/front/styles/globals.css
+++ b/front/styles/globals.css
@@ -2,8 +2,9 @@ html,
 body {
   padding: 0;
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
-    Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+  font-family: "Noto Sans KR", -apple-system, BlinkMacSystemFont, Segoe UI,
+    Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue,
+    sans-serif;
 }
 
 a {
@@ -11,6 +12,9 @@ a {
   text-decoration: none;
 }
 
+button {
+  font-family: "Noto Sans KR", sans-serif;
+}
 * {
   box-sizing: border-box;
 }


### PR DESCRIPTION
## [220714] LoginPage layout 구현 완료
- merge 요청자: @rnrn99 
- issue (링크) https://www.notion.so/LoginPage-UI-2f6bbae6e3f94d8a883f2977a84589c1 

## 1. PR 목적
- LoginPage layout 구현이 완료되었으므로 dev로 옮기고자 함.  


## 2. PR 내용
### login page 구성
#### iPhoneSE (375x667)
![image](https://user-images.githubusercontent.com/28249915/178914497-58efaf6c-3ff8-4f5b-b3dc-7f64e4726d9b.png)

#### Galaxy Fold 3 (674x842)
![image](https://user-images.githubusercontent.com/28249915/178914759-f1e8dab4-1be7-4d21-b719-194a6a3d59bc.png)


