### PR TITLE
[프론트] MainContainer height -> minHeight

### DIFF
--- a/front/common/userContainer/Container.style.ts
+++ b/front/common/userContainer/Container.style.ts
@@ -2,7 +2,7 @@ import { styled } from "styletron-react";
 
 export const MainContainer = styled("div", (props: { $bgColor: string }) => ({
   width: "100vw",
-  height: "100vh",
+  minHeight: "100vh",
   display: "flex",
   flexDirection: "column",
   backgroundColor: props.$bgColor,


### PR DESCRIPTION
## [220718] MainContainer height -> minHeight
- merge 요청자: @rnrn99 

## 1. PR 목적
- 배포 후 layout 이슈 발견으로 이를 고치고자 함.


## 2. PR 내용
- MainContainer의 height을 minHeight으로 변경