### PR TITLE
[Back] current user 조회 api 생성

### DIFF
--- a/back/package.json
+++ b/back/package.json
@@ -10,7 +10,7 @@
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "env TZ=Asia/Seoul nest start",
-    "start:dev": "env TZ=Asia/Seoul nest start --watch",
+    "start:dev": "nest start --watch",
     "start:debug": "env TZ=Asia/Seoul nest start --debug --watch",
     "start:prod": "env TZ=Asia/Seoul node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",

--- a/back/prisma/schema.prisma
+++ b/back/prisma/schema.prisma
@@ -42,7 +42,7 @@ model User {
   isDeleted        Boolean?           @default(false)
   createdAt        DateTime?          @default(now()) @db.Date
   birth            String?            @db.VarChar(9)
-  updatedAt        DateTime?          @updatedAt  
+  updatedAt        DateTime?          @updatedAt
   refreshToken     String?            @db.VarChar(500)
   PharmacyBookMark PharmacyBookMark[]
 }

--- a/back/src/auth/auth.controller.ts
+++ b/back/src/auth/auth.controller.ts
@@ -206,6 +206,32 @@ export class AuthController {
     };
   }
 
+  @Get('current')
+  @UseGuards(RefreshGuard)
+  @ApiOperation({
+    summary: '현재 로그인 API',
+    description: '현재 로그인되어있는 유저를 불러온다.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '현재 로그인 유저 조회 성공',
+  })
+  @ApiCookieAuth('refreshToken')
+  @ApiCookieAuth('accessToken')
+  async current(@GetCurrentUserId() id: string) {
+    const user = await this.authService.getUserById(id);
+    return {
+      statusCode: 200,
+      message: '현재 로그인 유저 조회에 성공했습니다.',
+      user: {
+        id,
+        email: user.email,
+        name: user.name,
+        profileImg: user.profileImg,
+      },
+    };
+  }
+
   // recaptcha를 guard로 대체 가능! 비용 절감
   // 일단은 api로 놔둠
   // @HttpCode(200)


### PR DESCRIPTION
## [2022-07-29] current user 조회 api 생성
- merge 요청자: @ParkSuJeong74 

## 1. PR 목적
현재 로그인된 유저 정보를 가져오는 api 생성

## 2. PR 내용
로그인된 유저의 id, email, name, profileImg 를 임시로 반환. 향후 access token이 만료되었을때 refresh token으로 access token을 재발행하는 기능을 추가해야함