### PR TITLE
[프론트] Api 분리(Fetch Wrapper 적용)

### DIFF
--- a/front/api/api.ts
+++ b/front/api/api.ts
@@ -1,0 +1,44 @@
+const baseUrl = process.env.NEXT_PUBLIC_SERVER_URL;
+
+const get = (endpoint: string) => {
+  const url = baseUrl + endpoint;
+
+  return fetch(url, {
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+  });
+};
+
+const post = <T>(endpoint: string, data: T) => {
+  const url = baseUrl + endpoint;
+
+  return fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+    credentials: "include",
+  });
+};
+
+const put = <T>(endpoint: string, data: T) => {
+  const url = baseUrl + endpoint;
+
+  return fetch(url, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+    credentials: "include",
+  });
+};
+
+const del = (endpoint: string) => {
+  const url = baseUrl + endpoint;
+
+  return fetch(url, {
+    method: "DELETE",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+  });
+};
+
+export { get, post, put, del as delete };

--- a/front/components/login/LoginForm.tsx
+++ b/front/components/login/LoginForm.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 import { useRouter } from "next/router";
+import Link from "next/link";
 import { useState, useRef } from "react";
 import { useFormik } from "formik";
 import * as Yup from "yup";
@@ -8,6 +9,7 @@ import ReCAPTCHA from "react-google-recaptcha";
 import { useMutation } from "react-query";
 import { useAtom } from "jotai";
 import { userAtom } from "@atom/userAtom";
+import * as Api from "@api";
 import { SigninResponse } from "@modelTypes/signinResponse";
 import { SigninUserDto as LoginTypes } from "@modelTypes/signinUserDto";
 import { BUTTON_COLOR, ERROR_MSG_COLOR, ROUTE } from "@utils/constant";
@@ -30,21 +32,13 @@ import {
   KakaoBtn,
   GoogleBtn,
 } from "./LoginForm.style";
-import Link from "next/link";
 
 type LoginFormValues = Pick<LoginTypes, "email" | "password">;
 
 const loginHandler = async (data: LoginTypes) => {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_SERVER_URL}/auth/signin`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(data),
-    credentials: "include",
-  });
-
+  const res = await Api.post<LoginTypes>("/auth/signin", data);
   const result: SigninResponse = await res.json();
+
   if (result.statusCode >= 400) {
     throw new Error(result.message);
   }

--- a/front/components/register/UserDataForm.tsx
+++ b/front/components/register/UserDataForm.tsx
@@ -19,6 +19,7 @@ import { useFormik } from "formik";
 import { useMutation } from "react-query";
 import * as Yup from "yup";
 import ReactTooltip from "react-tooltip";
+import * as Api from "@api";
 
 interface UserDataFormProps {
   applySubmit: ApplySubmitValues;
@@ -55,14 +56,8 @@ const userInitialValue: RegisterValues = {
 type PostUserData = Omit<RegisterValues, "checkPassword">;
 
 const postRegisterAPI = async (data: PostUserData) => {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_SERVER_URL}/auth/signup`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(data),
-  });
-  const result = await res.json();
+  const res = await Api.post<PostUserData>("/auth/signup", data);
+  const result: CreateUserResponse = await res.json();
   if (result.statusCode >= 400) {
     throw new Error(result.message);
   }
@@ -86,7 +81,7 @@ function UserDataForm({ applySubmit }: UserDataFormProps) {
   const router = useRouter();
 
   const mutation = useMutation(postRegisterAPI, {
-    onSuccess: (data: CreateUserResponse, variables) => {
+    onSuccess: (data, variables) => {
       router.push(
         {
           pathname: "/login",

--- a/front/pages/_app.tsx
+++ b/front/pages/_app.tsx
@@ -11,6 +11,7 @@ import { useAtom } from "jotai";
 import { userAtom } from "@atom/userAtom";
 import { styletron } from "@utils/styletron";
 import { URL_WITHOUT_HEADER, SILENT_REFRESH_TIME } from "@utils/constant";
+import * as Api from "@api";
 import { SigninResponse as CurrentUserResponse } from "@modelTypes/signinResponse";
 import { RefreshResponse } from "@modelTypes/refreshResponse";
 import Header from "@header/Header";
@@ -23,12 +24,8 @@ const setScreenSize = () => {
 
 const getAccessToken = async () => {
   try {
-    const res = await fetch(
-      `${process.env.NEXT_PUBLIC_SERVER_URL}/auth/refresh`,
-      {
-        credentials: "include",
-      },
-    );
+    const res = await Api.get("/auth/refresh");
+
     const result: RefreshResponse = await res.json();
 
     if (result.statusCode >= 400) {
@@ -54,12 +51,7 @@ function MyApp({ Component, pageProps }: AppProps) {
   useEffect(() => {
     async function getUsers() {
       try {
-        const res = await fetch(
-          `${process.env.NEXT_PUBLIC_SERVER_URL}/auth/current`,
-          {
-            credentials: "include",
-          },
-        );
+        const res = await Api.get("/auth/current");
         const result: CurrentUserResponse = await res.json();
 
         if (result.statusCode === 200) {

--- a/front/tsconfig.json
+++ b/front/tsconfig.json
@@ -31,7 +31,7 @@
       "@mainComp/*": ["components/main/*"],
       "@registerComp/*": ["components/register/*"],
       "@searchComp/*": ["components/search/*"],
-      "@resultComp/*": ["components/search/result*"],
+      "@resultComp/*": ["components/search/result/*"],
       "@modelTypes/*": ["src/model/*"]
     }
   },

--- a/front/tsconfig.json
+++ b/front/tsconfig.json
@@ -19,6 +19,7 @@
     "paths": {
       "@lib/*": ["lib/*"],
       "@atom/*": ["atom/*"],
+      "@api": ["api/api"],
       "@utils/*": ["common/utils/*"],
       "@userContainer/*": ["common/userContainer/*"],
       "@modal/*": ["common/modal/*"],


### PR DESCRIPTION
## [220810] Api 분리(Fetch Wrapper 적용)
- merge 요청자:  @rnrn99 
- issue (링크): https://www.notion.so/api-bc9fec24fca24dd1b3c37a3936ee8b14

## 1. PR 목적
- fetch wrapper를 추가하였음.


## 2. PR 내용
- api > api.ts에 fetch wrapper를 추가함.
- 현재 dev branch에서 fetch를 사용하는 파일에 api.ts의 내용 적용함. (_app.tsx, LoginForm.tsx, UserDataForm.tsx)

설명은 [api.ts](https://www.notion.so/api-ts-849ffebfda4e4bff9a5333914a15c8d5)에 정리해두었습니다.