### PR TITLE
[Back] 비밀번호 변경 api 로직 변경

### DIFF
--- a/back/src/auth/auth.controller.ts
+++ b/back/src/auth/auth.controller.ts
@@ -134,7 +134,6 @@ export class AuthController {
       refreshToken,
     );
 
-    // cookie에 accessToken, refreshToken 저장
     res.cookie('AccessToken', accessToken, {
       maxAge: this.configService.get('JWT_EXPIRESIN'),
       httpOnly: true,

--- a/back/src/auth/auth.controller.ts
+++ b/back/src/auth/auth.controller.ts
@@ -45,6 +45,7 @@ import {
 import { MailService } from 'src/mail/mail.service';
 import { RedisService } from 'src/redis/redis.service';
 import { SmsService } from 'src/sms/sms.service';
+import { v4 as uuid } from 'uuid';
 import { AuthService } from './auth.service';
 import {
   ChangePasswordDto,
@@ -294,11 +295,15 @@ export class AuthController {
     @Body() findPasswordDto: FindPasswordDto,
   ): Promise<FindPasswordResponse> {
     const user: UserModel = await this.authService.findUser(findPasswordDto);
-    await this.authService.setPWChangeToken(user.id);
+    const passwordToken: string = uuid().toString();
+    await this.authService.setPWChangeToken(user.id, passwordToken);
+
     const result: boolean = await this.mailService.sendEmail(
       user.email,
       user.name,
+      passwordToken,
     );
+
     this.logger.verbose(`User ${user.email} send email to update Success!`);
     return {
       statusCode: 200,
@@ -317,22 +322,27 @@ export class AuthController {
     description: '토큰 검사 성공',
     type: FindPasswordResponse,
   })
-  @ApiParam({
+  @ApiQuery({
     name: 'email',
     required: true,
     description: '이메일',
   })
-  @ApiParam({
-    name: 'email',
+  @ApiQuery({
+    name: 'token',
     required: true,
-    description: '이메일',
+    description: '비밀번호 토큰',
   })
   @Get('change-password/check')
-  async checkPWToken(
-    @Param('email') email: string,
-  ): Promise<FindPasswordResponse> {
-    const user: UserModel = await this.authService.getUserByEmail(email);
-    await this.redisService.getKey('pw' + user.id);
+  async checkPWToken(@Query() query): Promise<FindPasswordResponse> {
+    const user: UserModel = await this.authService.getUserByEmail(query.email);
+    const token: string = await this.redisService.getKey('pw' + user.id);
+
+    if (
+      query.token !==
+      token.slice(this.configService.get('CHANGE_PASSWORD_KEY').length)
+    ) {
+      throw new ForbiddenException('토큰이 일치하지 않습니다.');
+    }
     this.logger.verbose(`User ${user.email} check pw token Success!`);
     return {
       statusCode: 200,
@@ -342,7 +352,7 @@ export class AuthController {
   }
 
   @HttpCode(200)
-  @Put('change-password')
+  @Put('change-password/:email')
   @ApiOperation({
     summary: '비밀번호 변경 API',
     description: '비밀번호를 변경 한다.',

--- a/back/src/auth/auth.controller.ts
+++ b/back/src/auth/auth.controller.ts
@@ -530,6 +530,10 @@ export class AuthController {
     };
   }
 
+  // 이메일 인증
+  // 이메일이 유효한지 검사하기
+  // 인증번호? 아니면 비밀번호 변경 이메일에서 멘트만 바꾸기
+
   // @HttpCode(200)
   // @Throttle(5, 1)
   // @Get('kakao')

--- a/back/src/auth/auth.controller.ts
+++ b/back/src/auth/auth.controller.ts
@@ -127,7 +127,6 @@ export class AuthController {
     const { accessToken, refreshToken }: Tokens =
       await this.authService.localSignin(signinUserDto, user);
 
-    // redis: save refresh-token
     await this.authService.saveRefreshToken(
       user.id,
       signinUserDto.isSignin,

--- a/back/src/auth/auth.service.ts
+++ b/back/src/auth/auth.service.ts
@@ -11,7 +11,6 @@ import { PrismaClientKnownRequestError } from '@prisma/client/runtime';
 import * as argon from 'argon2';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { RedisService } from 'src/redis/redis.service';
-import { v4 as uuid } from 'uuid';
 import { providerType } from './auth-provider.enum';
 import {
   ChangePasswordDto,
@@ -230,8 +229,7 @@ export class AuthService {
     return user.pop();
   }
 
-  async setPWChangeToken(id: string): Promise<string> {
-    const token: string = uuid().toString();
+  async setPWChangeToken(id: string, token: string): Promise<string> {
     const result: boolean = await this.redisService.setKey(
       'pw' + id,
       this.configService.get('CHANGE_PASSWORD_KEY') + token,

--- a/back/src/auth/auth.service.ts
+++ b/back/src/auth/auth.service.ts
@@ -1,7 +1,6 @@
 import {
   ForbiddenException,
   Injectable,
-  InternalServerErrorException,
   UnauthorizedException,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
@@ -32,15 +31,19 @@ export class AuthService {
   ) {}
 
   async getUserByEmail(email: string): Promise<User> {
-    const user: User = await this.prisma.user.findUnique({
-      where: { email },
-    });
+    try {
+      const user: User = await this.prisma.user.findUnique({
+        where: { email },
+      });
 
-    if (!user) {
-      throw new ForbiddenException('회원이 존재하지 않습니다.');
+      if (!user) {
+        throw new ForbiddenException('회원이 존재하지 않습니다.');
+      }
+
+      return user;
+    } catch {
+      throw new ForbiddenException('회원을 찾지 못했습니다.');
     }
-
-    return user;
   }
 
   async getUserById(id: string): Promise<User> {
@@ -85,7 +88,7 @@ export class AuthService {
           throw new ForbiddenException('이미 존재하는 이메일입니다.');
         }
       } else {
-        throw new InternalServerErrorException();
+        throw new ForbiddenException('회원을 저장하지 못했습니다.');
       }
     }
   }
@@ -215,7 +218,6 @@ export class AuthService {
       if (user.name !== findPasswordDto.name) {
         throw new ForbiddenException('회원이 존재하지 않습니다.');
       }
-
       return user;
     } catch (error) {
       throw new ForbiddenException('회원을 찾지 못했습니다.');
@@ -258,20 +260,6 @@ export class AuthService {
       throw new ForbiddenException('토큰을 저장할때 에러가 발생했습니다.');
     }
   }
-
-  // async kakaoLogin(kakaoLoginDto: OauthLoginDto) {
-  //   const user: User = await this.createOauthUser(kakaoLoginDto, 'kakao');
-  //   const { accessToken, refreshToken } = kakaoLoginDto;
-
-  //   // redis 저장
-  //   await this.redisService.setKey(
-  //     'ka' + user.id,
-  //     process.env.REFRESHTOKEN_KEY + refreshToken,
-  //     Number(process.env.JWT_REFRESH_EXPIRESIN) / 1000,
-  //   );
-
-  //   return { accessToken, refreshToken };
-  // }
 
   async createOauthUser(payload: OauthLoginDto, type: string): Promise<User> {
     let provider;
@@ -337,4 +325,18 @@ export class AuthService {
       throw new ForbiddenException('비밀번호를 변경하지 못했습니다.');
     }
   }
+
+  // async kakaoLogin(kakaoLoginDto: OauthLoginDto) {
+  //   const user: User = await this.createOauthUser(kakaoLoginDto, 'kakao');
+  //   const { accessToken, refreshToken } = kakaoLoginDto;
+
+  //   // redis 저장
+  //   await this.redisService.setKey(
+  //     'ka' + user.id,
+  //     process.env.REFRESHTOKEN_KEY + refreshToken,
+  //     Number(process.env.JWT_REFRESH_EXPIRESIN) / 1000,
+  //   );
+
+  //   return { accessToken, refreshToken };
+  // }
 }

--- a/back/src/auth/auth.service.ts
+++ b/back/src/auth/auth.service.ts
@@ -47,23 +47,31 @@ export class AuthService {
   }
 
   async getUserById(id: string): Promise<User> {
-    const user: User = await this.prisma.user.findUnique({
-      where: { id },
-    });
+    try {
+      const user: User = await this.prisma.user.findUnique({
+        where: { id },
+      });
 
-    if (!user) {
-      throw new ForbiddenException('회원이 존재하지 않습니다.');
+      if (!user) {
+        throw new ForbiddenException('회원이 존재하지 않습니다.');
+      }
+
+      return user;
+    } catch {
+      throw new ForbiddenException('회원을 찾지 못했습니다.');
     }
-
-    return user;
   }
 
   async getUserByPhone(phone: string): Promise<User> {
-    const user: User = await this.prisma.user.findUnique({
-      where: { phone },
-    });
+    try {
+      const user: User = await this.prisma.user.findUnique({
+        where: { phone },
+      });
 
-    return user;
+      return user;
+    } catch {
+      throw new ForbiddenException('회원을 찾지 못했습니다.');
+    }
   }
 
   async createUser(createUserDto: CreateUserDto): Promise<User> {
@@ -299,6 +307,8 @@ export class AuthService {
         process.env.REFRESHTOKEN_KEY + refreshToken,
         Number(process.env.JWT_REFRESH_EXPIRESIN) / 1000,
       );
+
+      console.log(accessToken, refreshToken);
 
       return { accessToken, refreshToken };
     } catch (error) {

--- a/back/src/mail/mail.service.ts
+++ b/back/src/mail/mail.service.ts
@@ -10,7 +10,11 @@ export class MailService {
     private readonly configService: ConfigService,
   ) {}
 
-  async sendEmail(email: string, name: string): Promise<boolean> {
+  async sendEmail(
+    email: string,
+    name: string,
+    token: string,
+  ): Promise<boolean> {
     const mailUrl = '/api/v1/mails';
     const result = await this.httpService
       .post(
@@ -23,9 +27,55 @@ export class MailService {
             `<p>안녕하세요. ${name} 님<p>아래의 링크를 통해 비밀번호를 재설정하실 수 있습니다.<p>` +
             `<a href='${this.configService.get(
               'CLIENT_URL',
-            )}/account/password/new/${email}'>비밀번호 재설정하기</a>` +
+            )}/account/password/new?email=${email}&token=${token}'>비밀번호 재설정하기</a>` +
             `<p>감사합니다. <p>devRangers 개발팀 드림<p>`,
           recipients: [{ address: email, name, type: 'R' }],
+        },
+        {
+          headers: {
+            'Content-Type': 'application/json',
+            'x-ncp-apigw-timestamp': new Date().getTime().toString(10),
+            'x-ncp-iam-access-key': this.configService.get('ACCESS_KEY_ID'),
+            'x-ncp-apigw-signature-v2': this.makeSign(
+              'POST',
+              mailUrl,
+              new Date().getTime().toString(10),
+              this.configService.get('ACCESS_KEY_ID'),
+              this.configService.get('SECRET_KEY'),
+            ),
+            'x-ncp-lang': 'ko-KR',
+          },
+        },
+      )
+      .toPromise();
+
+    if (!result || !result.data || result.data.count !== 1) {
+      throw new ForbiddenException('이메일 전송을 실패하였습니다.');
+    }
+    return true;
+  }
+
+  async sendInquiry(
+    email: string,
+    name: string,
+    description: string,
+  ): Promise<boolean> {
+    const mailUrl = '/api/v1/mails';
+    const result = await this.httpService
+      .post(
+        `${this.configService.get('MAIL_API_DOMAIN')}${mailUrl}`,
+        {
+          senderAddress: email,
+          senderName: name,
+          title: `[궁금해약] ${name} 님의 고객센터 문의입니다.`,
+          body: `<p> 문의 내용 : ${description}</p>`,
+          recipients: [
+            {
+              address: this.configService.get('SENDER_ADDRESS'),
+              name: 'DevRangers',
+              type: 'R',
+            },
+          ],
         },
         {
           headers: {


### PR DESCRIPTION
## [2022-08-16] 비밀번호 변경 api 로직 변경
- merge 요청자: @ParkSuJeong74 

## 1. PR 목적
- 비밀번호 변경 api 로직 변경

## 2. PR 내용
원래는 토큰의 유효기간만 검사해서 유효기간이 만료되지 않았다면 다 허용을 했지만, email 전송 후 redirect하는 url에서 token을 query로 넘기고 검사하는 api에서 token과 redis에 저장된 token의 일치여부도 검사하는 것으로 변경함 / 테스트 완료

추가 : 고객 센터 문의를 위한 mail service도 추가되었지만 스크럼 이후 변경될 가능성이 있음