### PR TITLE
[프론트] ErrorPage 구현, login error 처리

### DIFF
--- a/front/common/errorContainer/ErrorPage.style.ts
+++ b/front/common/errorContainer/ErrorPage.style.ts
@@ -1,0 +1,50 @@
+import { styled } from "styletron-react";
+
+export const Container = styled(
+  "div",
+  (props: {
+    $fullHeight: string;
+    $headerHeight: string;
+    $footerHeight: string;
+    $bgColor: string;
+  }) => ({
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
+    minHeight: `calc(${props.$fullHeight} - (${props.$headerHeight} + ${props.$footerHeight}))`,
+    backgroundColor: props.$bgColor,
+  }),
+);
+
+export const Card = styled("div", {
+  width: "80vw",
+  height: "45vh",
+  display: "grid",
+  gridTemplateRows: "2fr 1fr 2.5fr 1.2fr",
+  justifyItems: "center",
+  alignItems: "center",
+  padding: "1rem 0",
+  backgroundColor: "#fff",
+  borderRadius: "20px",
+});
+
+export const Icon = styled("div", (props: { $iconColor: string }) => ({
+  fontSize: "2.5rem",
+  color: props.$iconColor,
+}));
+
+export const Title = styled("h1", {
+  fontSize: "1.5rem",
+  fontWeight: "bold",
+});
+
+export const Description = styled("pre", {
+  textAlign: "center",
+  lineHeight: 1.2,
+  color: "#434343",
+});
+
+export const Message = styled("pre", {
+  fontSize: "0.9rem",
+  fontWeight: "bold",
+});

--- a/front/common/errorContainer/ErrorPage.tsx
+++ b/front/common/errorContainer/ErrorPage.tsx
@@ -1,0 +1,75 @@
+import { useRouter } from "next/router";
+import { useState, useEffect } from "react";
+import {
+  HEADER_HEIGHT,
+  FOOTER_HEIGHT,
+  FULL_HEIGHT,
+  MAIN_COLOR,
+  ACCENT_COLOR,
+} from "@utils/constant";
+import { BsFillExclamationCircleFill } from "react-icons/bs";
+import {
+  Container,
+  Card,
+  Icon,
+  Title,
+  Description,
+  Message,
+} from "./ErrorPage.style";
+
+interface ErrorPageProps {
+  title: string;
+  description: string;
+  link: string;
+  pageName: string;
+}
+
+const COUNT_TIME = 3;
+
+function ErrorPage({ title, description, link, pageName }: ErrorPageProps) {
+  const router = useRouter();
+  const [count, setCount] = useState(COUNT_TIME);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      router.push({ pathname: link });
+    }, COUNT_TIME * 1000);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, []);
+
+  useEffect(() => {
+    const countdown = setInterval(() => {
+      if (count > 0) {
+        setCount((cur) => cur - 1);
+      }
+    }, 1000);
+
+    return () => {
+      clearTimeout(countdown);
+    };
+  }, [count]);
+
+  return (
+    <Container
+      $fullHeight={FULL_HEIGHT}
+      $headerHeight={HEADER_HEIGHT}
+      $footerHeight={FOOTER_HEIGHT}
+      $bgColor={MAIN_COLOR}>
+      <Card>
+        <Icon $iconColor={ACCENT_COLOR}>
+          <BsFillExclamationCircleFill />
+        </Icon>
+        <Title>{title}</Title>
+        <Description>{description}</Description>
+        <Message>
+          {count}초 뒤 {pageName}(으)로 이동합니다.
+        </Message>
+      </Card>
+    </Container>
+  );
+}
+
+export default ErrorPage;

--- a/front/common/errorContainer/ErrorTypes.ts
+++ b/front/common/errorContainer/ErrorTypes.ts
@@ -1,7 +1,9 @@
+import { ROUTE } from "@utils/constant";
+
 export const SnsLoginError = {
   title: "SNS 로그인 에러",
   description:
     "현재 로그인을 시도하신 이메일이\n이미 사용중인 이메일이거나\n서버 측의 문제일 수 있습니다.",
-  link: "/login",
+  link: ROUTE.LOGIN,
   pageName: "로그인 페이지",
 };

--- a/front/common/errorContainer/ErrorTypes.ts
+++ b/front/common/errorContainer/ErrorTypes.ts
@@ -1,0 +1,7 @@
+export const SnsLoginError = {
+  title: "SNS 로그인 에러",
+  description:
+    "현재 로그인을 시도하신 이메일이\n이미 사용중인 이메일이거나\n서버 측의 문제일 수 있습니다.",
+  link: "/login",
+  pageName: "로그인 페이지",
+};

--- a/front/components/login/LoginForm.tsx
+++ b/front/components/login/LoginForm.tsx
@@ -60,9 +60,8 @@ function LoginForm() {
       Api.post<SigninResponse, LoginTypes>("/auth/signin", data),
     {
       onSuccess: ({ user }) => {
-        console.log(user);
         setUser(user);
-        router.push("/");
+        router.push(ROUTE.MAIN);
       },
       onError: ({ message }) => {
         console.log(message);

--- a/front/pages/login/error.tsx
+++ b/front/pages/login/error.tsx
@@ -1,0 +1,9 @@
+import type { NextPage } from "next";
+import ErrorPage from "@errorContainer/ErrorPage";
+import { SnsLoginError } from "@errorContainer/ErrorTypes";
+
+const LoginErrorPage: NextPage = () => {
+  return <ErrorPage {...SnsLoginError} />;
+};
+
+export default LoginErrorPage;

--- a/front/tsconfig.json
+++ b/front/tsconfig.json
@@ -27,6 +27,7 @@
       "@modal/*": ["common/modal/*"],
       "@sidebar/*": ["common/sidebar/*"],
       "@userContainer/*": ["common/userContainer/*"],
+      "@errorContainer/*": ["common/errorContainer/*"],
       "@utils/*": ["common/utils/*"],
       "@accountComp/*": ["components/account/*"],
       "@loginComp/*": ["components/login/*"],


### PR DESCRIPTION
## [220817] ErrorPage 구현, login error 처리
- merge 요청자: @rnrn99 

## 1. PR 목적
- 에러 발생 시 에러 메세지를 사용자에게 보여주고 강제로 링크 이동할 페이지를 만듦.


## 2. PR 내용
![image](https://user-images.githubusercontent.com/28249915/185055884-f2d05507-251d-472c-ac79-5239a39109c4.png)

- 에러 제목
- 에러 설명
- 이동할 페이지 이름
- 링크