### PR TITLE
[프론트] gray color 추가, refresh api 에러 이슈 해결

### DIFF
--- a/front/common/userContainer/Container.style.ts
+++ b/front/common/userContainer/Container.style.ts
@@ -49,19 +49,22 @@ export const InputContainer = styled("div", {
   justifyItems: "center",
 });
 
-export const Input = styled("input", {
-  width: "65%",
-  height: "3.5rem",
-  border: 0,
-  borderRadius: "25px",
-  fontSize: "1rem",
-  padding: "0 1rem",
-  "::-webkit-input-placeholder": {
-    textAlign: "center",
-    fontFamily: "'Noto Sans KR', sans-serif",
-    color: "#A4A4A4",
-  },
-});
+export const Input = styled(
+  "input",
+  (props: { $placeholderColor: string }) => ({
+    width: "65%",
+    height: "3.5rem",
+    border: 0,
+    borderRadius: "25px",
+    fontSize: "1rem",
+    padding: "0 1rem",
+    "::-webkit-input-placeholder": {
+      textAlign: "center",
+      fontFamily: "'Noto Sans KR', sans-serif",
+      color: props.$placeholderColor,
+    },
+  }),
+);
 
 export const ErrorMessage = styled("div", (props: { $txtColor: string }) => ({
   textAlign: "start",

--- a/front/common/utils/constant.ts
+++ b/front/common/utils/constant.ts
@@ -1,8 +1,10 @@
 export const MAIN_COLOR = "#A8C0EA";
 export const SUB_COLOR = "#9ADCDD";
 export const ACCENT_COLOR = "#3C5A93";
+export const SEMI_ACCENT_COLOR = "#567BC4";
 export const ERROR_MSG_COLOR = "#bd0000";
 export const BOX_COLOR = "#2A306A";
+export const GRAY_COLOR = "#A4A4A4";
 
 export const HEADER_HEIGHT = "10vh";
 export const FOOTER_HEIGHT = "8vh";

--- a/front/components/account/findEmail/AuthForm.style.ts
+++ b/front/components/account/findEmail/AuthForm.style.ts
@@ -24,25 +24,22 @@ export const InputContainer = styled("div", {
   alignItems: "center",
 });
 
-export const Input = styled("input", {
+export const Input = styled("input", (props: { $borderColor: string }) => ({
   width: "50%",
   height: "2.5rem",
   borderRadius: "25px",
-  border: "0.1px solid #a4a4a4",
+  border: `1px solid ${props.$borderColor}`,
   textAlign: "center",
   fontSize: "1.2rem",
   marginRight: "0.5rem",
-});
+}));
 
-export const SubmitBtn = styled(
-  "button",
-  (props: { $btnColor: string; $disabled: boolean }) => ({
-    borderRadius: "25px",
-    backgroundColor: props.$disabled ? "#A4A4A4" : props.$btnColor,
-    color: "#fff",
-    padding: "0.5rem 1rem",
-  }),
-);
+export const SubmitBtn = styled("button", (props: { $btnColor: string }) => ({
+  borderRadius: "25px",
+  backgroundColor: props.$btnColor,
+  color: "#fff",
+  padding: "0.5rem 1rem",
+}));
 
 export const RetryBtnContainer = styled("div", {
   display: "grid",
@@ -67,7 +64,7 @@ export const CloseBtnContainer = styled("div", {
   alignItems: "center",
 });
 
-export const CloseBtn = styled("button", {
-  color: "#a4a4a4",
+export const CloseBtn = styled("button", (props: { $btnColor: string }) => ({
+  color: props.$btnColor,
   marginRight: "0.5rem",
-});
+}));

--- a/front/components/account/findEmail/AuthForm.tsx
+++ b/front/components/account/findEmail/AuthForm.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from "next/router";
 import { useState } from "react";
 import { useQuery } from "react-query";
-import { MAIN_COLOR, ACCENT_COLOR, ROUTE } from "@utils/constant";
+import { MAIN_COLOR, ACCENT_COLOR, GRAY_COLOR, ROUTE } from "@utils/constant";
 import {
   FormContainer,
   TitleContainer,
@@ -66,11 +66,11 @@ function AuthForm({ onClose, phone }: AuthFormProps) {
           onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
             setCode(e.target.value)
           }
+          $borderColor={GRAY_COLOR}
         />
         <SubmitBtn
           type="button"
-          $btnColor={MAIN_COLOR}
-          $disabled={code.length === 0}
+          $btnColor={code.length === 0 ? GRAY_COLOR : MAIN_COLOR}
           onClick={() => setIsSubmitted(true)}
           disabled={code.length === 0}>
           확인
@@ -85,7 +85,7 @@ function AuthForm({ onClose, phone }: AuthFormProps) {
       </RetryBtnContainer>
 
       <CloseBtnContainer>
-        <CloseBtn type="button" onClick={onClose}>
+        <CloseBtn type="button" onClick={onClose} $btnColor={GRAY_COLOR}>
           닫기
         </CloseBtn>
       </CloseBtnContainer>

--- a/front/components/account/findEmail/FindEmailForm.tsx
+++ b/front/components/account/findEmail/FindEmailForm.tsx
@@ -6,7 +6,12 @@ import { useMutation } from "react-query";
 import * as Api from "@api";
 import { FindAccountResponse } from "@modelTypes/findAccountResponse";
 import { FindAccountDto as FindAccountValues } from "@modelTypes/findAccountDto";
-import { ERROR_MSG_COLOR, SUB_COLOR, ACCENT_COLOR } from "@utils/constant";
+import {
+  ERROR_MSG_COLOR,
+  SUB_COLOR,
+  ACCENT_COLOR,
+  GRAY_COLOR,
+} from "@utils/constant";
 import {
   InputContainer,
   Input,
@@ -122,6 +127,7 @@ function FindEmailForm() {
               onChange={formik.handleChange}
               onBlur={formik.handleBlur}
               value={formik.values.name}
+              $placeholderColor={GRAY_COLOR}
             />
             <ErrorMessage $txtColor={ERROR_MSG_COLOR}>
               {formik.touched.name && formik.errors.name}
@@ -139,6 +145,7 @@ function FindEmailForm() {
               onChange={formik.handleChange}
               onBlur={formik.handleBlur}
               value={formik.values.birth}
+              $placeholderColor={GRAY_COLOR}
             />
             <ErrorMessage $txtColor={ERROR_MSG_COLOR}>
               {formik.touched.birth && formik.errors.birth}

--- a/front/components/account/findPassword/FindPasswordForm.style.ts
+++ b/front/components/account/findPassword/FindPasswordForm.style.ts
@@ -8,26 +8,7 @@ export const Form = styled("form", {
   padding: "1rem",
 });
 
-export const Input = styled("input", {
-  width: "80%",
-  maxWidth: "25rem",
-  minHeight: "3.5rem",
-
-  backgroundColor: "#fff",
-  border: "none",
-  borderRadius: "25px",
-
-  outline: "0",
-  fontSize: "1.2rem",
-  padding: "0 1rem",
-
-  "::-webkit-input-placeholder": {
-    textAlign: "center",
-    color: "#A4A4A4",
-  },
-});
-
-export const ErrorMessage = styled("div", {
+export const ErrorMessage = styled("div", (props: { $txtColor: string }) => ({
   textAlign: "start",
   width: "80%",
   maxWidth: "25rem",
@@ -37,22 +18,5 @@ export const ErrorMessage = styled("div", {
   margin: "0.3rem 0 0.3rem 0.2rem",
 
   fontSize: "0.9rem",
-  color: "#bd0000",
-});
-
-export const FindBtn = styled("button", (props: { $bgColor: string }) => ({
-  width: "80%",
-  maxWidth: "25rem",
-  minHeight: "3.5rem",
-
-  backgroundColor: props.$bgColor,
-  border: "none",
-  borderRadius: "25px",
-
-  outline: "0",
-  fontSize: "1.2rem",
-  padding: "0 1rem",
-
-  fontWeight: "bold",
-  color: "#fff",
+  color: props.$txtColor,
 }));

--- a/front/components/account/findPassword/FindPasswordForm.tsx
+++ b/front/components/account/findPassword/FindPasswordForm.tsx
@@ -1,4 +1,4 @@
-import { SUB_COLOR } from "@utils/constant";
+import { SUB_COLOR, GRAY_COLOR, ERROR_MSG_COLOR } from "@utils/constant";
 import { useFormik } from "formik";
 import * as Yup from "yup";
 import {
@@ -49,11 +49,14 @@ function FindPasswordForm() {
           type="email"
           {...findPasswordFormik.getFieldProps("email")}
           placeholder="이메일"
+          $placeholderColor={GRAY_COLOR}
         />
         {findPasswordFormik.touched.email && findPasswordFormik.errors.email ? (
-          <ErrorMessage>{findPasswordFormik.errors.email}</ErrorMessage>
+          <ErrorMessage $txtColor={ERROR_MSG_COLOR}>
+            {findPasswordFormik.errors.email}
+          </ErrorMessage>
         ) : (
-          <ErrorMessage />
+          <ErrorMessage $txtColor={ERROR_MSG_COLOR} />
         )}
       </InputContainer>
       <InputContainer>
@@ -62,11 +65,14 @@ function FindPasswordForm() {
           type="text"
           {...findPasswordFormik.getFieldProps("name")}
           placeholder="이름"
+          $placeholderColor={GRAY_COLOR}
         />
         {findPasswordFormik.touched.name && findPasswordFormik.errors.name ? (
-          <ErrorMessage>{findPasswordFormik.errors.name}</ErrorMessage>
+          <ErrorMessage $txtColor={ERROR_MSG_COLOR}>
+            {findPasswordFormik.errors.name}
+          </ErrorMessage>
         ) : (
-          <ErrorMessage />
+          <ErrorMessage $txtColor={ERROR_MSG_COLOR} />
         )}
       </InputContainer>
       <InputContainer>
@@ -75,11 +81,14 @@ function FindPasswordForm() {
           type="number"
           {...findPasswordFormik.getFieldProps("birth")}
           placeholder="생년월일"
+          $placeholderColor={GRAY_COLOR}
         />
         {findPasswordFormik.touched.birth && findPasswordFormik.errors.birth ? (
-          <ErrorMessage>{findPasswordFormik.errors.birth}</ErrorMessage>
+          <ErrorMessage $txtColor={ERROR_MSG_COLOR}>
+            {findPasswordFormik.errors.birth}
+          </ErrorMessage>
         ) : (
-          <ErrorMessage />
+          <ErrorMessage $txtColor={ERROR_MSG_COLOR} />
         )}
       </InputContainer>
       <FindBtn type="submit" $btnColor={SUB_COLOR}>

--- a/front/components/account/newPassword/NewPasswordForm.tsx
+++ b/front/components/account/newPassword/NewPasswordForm.tsx
@@ -1,4 +1,4 @@
-import { SUB_COLOR, ERROR_MSG_COLOR } from "@utils/constant";
+import { SUB_COLOR, ERROR_MSG_COLOR, GRAY_COLOR } from "@utils/constant";
 import { useFormik } from "formik";
 import * as Yup from "yup";
 import {
@@ -45,6 +45,7 @@ function NewPasswordForm() {
           type="password"
           {...newPasswordFormik.getFieldProps("password")}
           placeholder="새로운 비밀번호"
+          $placeholderColor={GRAY_COLOR}
         />
         {newPasswordFormik.touched.password &&
         newPasswordFormik.errors.password ? (
@@ -61,6 +62,7 @@ function NewPasswordForm() {
           type="password"
           {...newPasswordFormik.getFieldProps("checkPassword")}
           placeholder="비밀번호 확인"
+          $placeholderColor={GRAY_COLOR}
         />
         {newPasswordFormik.touched.checkPassword &&
         newPasswordFormik.errors.checkPassword ? (

--- a/front/components/login/LoginForm.tsx
+++ b/front/components/login/LoginForm.tsx
@@ -12,7 +12,7 @@ import { userAtom } from "@atom/userAtom";
 import * as Api from "@api";
 import { SigninResponse } from "@modelTypes/signinResponse";
 import { SigninUserDto as LoginTypes } from "@modelTypes/signinUserDto";
-import { SUB_COLOR, ERROR_MSG_COLOR, ROUTE } from "@utils/constant";
+import { SUB_COLOR, ERROR_MSG_COLOR, GRAY_COLOR, ROUTE } from "@utils/constant";
 import {
   InputContainer,
   Input,
@@ -106,6 +106,7 @@ function LoginForm() {
               onChange={formik.handleChange}
               onBlur={formik.handleBlur}
               value={formik.values.email}
+              $placeholderColor={GRAY_COLOR}
             />
             <ErrorMessage $txtColor={ERROR_MSG_COLOR}>
               {formik.touched.email && formik.errors.email}
@@ -124,6 +125,7 @@ function LoginForm() {
               data-tip="password-tooltip"
               data-for="password-tooltip"
               autoComplete="true"
+              $placeholderColor={GRAY_COLOR}
             />
             {formik.touched.password && formik.errors.password ? (
               <>

--- a/front/components/register/Authentication.tsx
+++ b/front/components/register/Authentication.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { ACCENT_COLOR } from "@utils/constant";
+import { ACCENT_COLOR, GRAY_COLOR, ERROR_MSG_COLOR } from "@utils/constant";
 import {
   AuthenticationForm,
   AuthenticationInput,
@@ -218,6 +218,7 @@ function Authentication({
             maxLength={11}
             {...phoneNumberFormik.getFieldProps("phoneNumber")}
             placeholder="- 제외 휴대폰번호"
+            $placeholderColor={GRAY_COLOR}
           />
           <SubmitAuthenticationBtn
             type="submit"
@@ -229,9 +230,11 @@ function Authentication({
         </PhoneNumberContainer>
         {phoneNumberFormik.touched.phoneNumber &&
         phoneNumberFormik.errors.phoneNumber ? (
-          <ErrorMessage>{phoneNumberFormik.errors.phoneNumber}</ErrorMessage>
+          <ErrorMessage $txtColor={ERROR_MSG_COLOR}>
+            {phoneNumberFormik.errors.phoneNumber}
+          </ErrorMessage>
         ) : (
-          <ErrorMessage />
+          <ErrorMessage $txtColor={ERROR_MSG_COLOR} />
         )}
       </AuthenticationForm>
 
@@ -242,6 +245,7 @@ function Authentication({
             type="number"
             {...authenticationFormik.getFieldProps("authenticationNumber")}
             placeholder="인증번호"
+            $placeholderColor={GRAY_COLOR}
           />
           <SubmitAuthenticationBtn
             type="submit"
@@ -258,11 +262,11 @@ function Authentication({
         </PhoneNumberContainer>
         {authenticationFormik.touched.authenticationNumber &&
         authenticationFormik.errors.authenticationNumber ? (
-          <ErrorMessage>
+          <ErrorMessage $txtColor={ERROR_MSG_COLOR}>
             {authenticationFormik.errors.authenticationNumber}
           </ErrorMessage>
         ) : (
-          <ErrorMessage />
+          <ErrorMessage $txtColor={ERROR_MSG_COLOR} />
         )}
       </AuthenticationForm>
       <CheckboxContainer>

--- a/front/components/register/RegisterForm.style.ts
+++ b/front/components/register/RegisterForm.style.ts
@@ -54,26 +54,29 @@ export const SubmitButton = styled(
   }),
 );
 
-export const Input = styled("input", {
-  width: "80%",
-  maxWidth: "25rem",
-  minHeight: "3.5rem",
+export const Input = styled(
+  "input",
+  (props: { $placeholderColor: string }) => ({
+    width: "80%",
+    maxWidth: "25rem",
+    minHeight: "3.5rem",
 
-  backgroundColor: "#fff",
-  border: "none",
-  borderRadius: "25px",
+    backgroundColor: "#fff",
+    border: "none",
+    borderRadius: "25px",
 
-  outline: "0",
-  fontSize: "1.2rem",
-  padding: "0 1rem",
+    outline: "0",
+    fontSize: "1.2rem",
+    padding: "0 1rem",
 
-  "::-webkit-input-placeholder": {
-    textAlign: "center",
-    color: "#A4A4A4",
-  },
-});
+    "::-webkit-input-placeholder": {
+      textAlign: "center",
+      color: props.$placeholderColor,
+    },
+  }),
+);
 
-export const ErrorMessage = styled("div", {
+export const ErrorMessage = styled("div", (props: { $txtColor: string }) => ({
   textAlign: "start",
   width: "80%",
   maxWidth: "25rem",
@@ -83,8 +86,8 @@ export const ErrorMessage = styled("div", {
   margin: "0.3rem 0 0.3rem 0.2rem",
 
   fontSize: "0.9rem",
-  color: "#bd0000",
-});
+  color: props.$txtColor,
+}));
 
 export const SelfAuthenticationLine = styled(
   "div",
@@ -129,25 +132,29 @@ export const PhoneNumberContainer = styled("div", {
   alignItems: "center",
 });
 
-export const AuthenticationInput = styled("input", {
-  maxWidth: "25rem",
-  minHeight: "3.5rem",
+export const AuthenticationInput = styled(
+  "input",
+  (props: { $placeholderColor: string }) => ({
+    maxWidth: "25rem",
+    minHeight: "3.5rem",
 
-  backgroundColor: "#fff",
-  border: "none",
-  borderRadius: "25px",
+    backgroundColor: "#fff",
+    border: "none",
+    borderRadius: "25px",
 
-  outline: "0",
-  fontSize: "1.2rem",
-  padding: "0 1rem",
+    outline: "0",
+    fontSize: "1.2rem",
+    padding: "0 1rem",
 
-  "::-webkit-input-placeholder": {
-    textAlign: "center",
-    color: "#A4A4A4",
-  },
-  width: "70%",
-  marginRight: "0.7rem",
-});
+    width: "70%",
+    marginRight: "0.7rem",
+
+    "::-webkit-input-placeholder": {
+      textAlign: "center",
+      color: props.$placeholderColor,
+    },
+  }),
+);
 
 export const SubmitAuthenticationBtn = styled(
   "button",

--- a/front/components/register/UserDataForm.tsx
+++ b/front/components/register/UserDataForm.tsx
@@ -1,6 +1,11 @@
 import { useState } from "react";
 import { useRouter } from "next/router";
-import { ACCENT_COLOR, SUB_COLOR } from "@utils/constant";
+import {
+  ACCENT_COLOR,
+  SUB_COLOR,
+  ERROR_MSG_COLOR,
+  GRAY_COLOR,
+} from "@utils/constant";
 import { BsFillExclamationCircleFill } from "react-icons/bs";
 import {
   ErrorMessage,
@@ -168,11 +173,14 @@ function UserDataForm({ applySubmit }: UserDataFormProps) {
           inputMode="email"
           {...userDataFormik.getFieldProps("email")}
           placeholder="이메일"
+          $placeholderColor={GRAY_COLOR}
         />
         {userDataFormik.touched.email && userDataFormik.errors.email ? (
-          <ErrorMessage>{userDataFormik.errors.email}</ErrorMessage>
+          <ErrorMessage $txtColor={ERROR_MSG_COLOR}>
+            {userDataFormik.errors.email}
+          </ErrorMessage>
         ) : (
-          <ErrorMessage />
+          <ErrorMessage $txtColor={ERROR_MSG_COLOR} />
         )}
 
         <Input
@@ -180,11 +188,14 @@ function UserDataForm({ applySubmit }: UserDataFormProps) {
           type="text"
           {...userDataFormik.getFieldProps("name")}
           placeholder="이름"
+          $placeholderColor={GRAY_COLOR}
         />
         {userDataFormik.touched.name && userDataFormik.errors.name ? (
-          <ErrorMessage>{userDataFormik.errors.name}</ErrorMessage>
+          <ErrorMessage $txtColor={ERROR_MSG_COLOR}>
+            {userDataFormik.errors.name}
+          </ErrorMessage>
         ) : (
-          <ErrorMessage />
+          <ErrorMessage $txtColor={ERROR_MSG_COLOR} />
         )}
 
         <Input
@@ -195,10 +206,13 @@ function UserDataForm({ applySubmit }: UserDataFormProps) {
           autoComplete="true"
           data-tip="password-tooltip"
           data-for="password-tooltip"
+          $placeholderColor={GRAY_COLOR}
         />
         {userDataFormik.touched.password && userDataFormik.errors.password ? (
           <>
-            <ErrorMessage>필수 입력 란입니다.</ErrorMessage>
+            <ErrorMessage $txtColor={ERROR_MSG_COLOR}>
+              필수 입력 란입니다.
+            </ErrorMessage>
 
             <ReactTooltip
               key="password-tooltip"
@@ -208,7 +222,7 @@ function UserDataForm({ applySubmit }: UserDataFormProps) {
             </ReactTooltip>
           </>
         ) : (
-          <ErrorMessage />
+          <ErrorMessage $txtColor={ERROR_MSG_COLOR} />
         )}
 
         <Input
@@ -217,12 +231,15 @@ function UserDataForm({ applySubmit }: UserDataFormProps) {
           {...userDataFormik.getFieldProps("checkPassword")}
           placeholder="비밀번호 확인"
           autoComplete="true"
+          $placeholderColor={GRAY_COLOR}
         />
         {userDataFormik.touched.checkPassword &&
         userDataFormik.errors.checkPassword ? (
-          <ErrorMessage>{userDataFormik.errors.checkPassword}</ErrorMessage>
+          <ErrorMessage $txtColor={ERROR_MSG_COLOR}>
+            {userDataFormik.errors.checkPassword}
+          </ErrorMessage>
         ) : (
-          <ErrorMessage />
+          <ErrorMessage $txtColor={ERROR_MSG_COLOR} />
         )}
 
         <Input
@@ -232,11 +249,14 @@ function UserDataForm({ applySubmit }: UserDataFormProps) {
           inputMode="numeric"
           {...userDataFormik.getFieldProps("birth")}
           placeholder="생년월일(8자리)"
+          $placeholderColor={GRAY_COLOR}
         />
         {userDataFormik.touched.birth && userDataFormik.errors.birth ? (
-          <ErrorMessage>{userDataFormik.errors.birth}</ErrorMessage>
+          <ErrorMessage $txtColor={ERROR_MSG_COLOR}>
+            {userDataFormik.errors.birth}
+          </ErrorMessage>
         ) : (
-          <ErrorMessage />
+          <ErrorMessage $txtColor={ERROR_MSG_COLOR} />
         )}
 
         <SelfAuthenticationLine $lineColor={ACCENT_COLOR}>

--- a/front/components/search/pharmacy/PharmInfoModal.style.ts
+++ b/front/components/search/pharmacy/PharmInfoModal.style.ts
@@ -53,6 +53,6 @@ export const CloseBtnContainer = styled("div", {
   alignItems: "center",
 });
 
-export const CloseBtn = styled("button", {
-  color: "#a4a4a4",
-});
+export const CloseBtn = styled("button", (props: { $btnColor: string }) => ({
+  color: props.$btnColor,
+}));

--- a/front/components/search/pharmacy/PharmInfoModal.tsx
+++ b/front/components/search/pharmacy/PharmInfoModal.tsx
@@ -1,4 +1,4 @@
-import { MAIN_COLOR } from "@utils/constant";
+import { MAIN_COLOR, GRAY_COLOR } from "@utils/constant";
 import { BsFillTelephoneFill } from "react-icons/bs";
 import { PharmacyResponse } from "@modelTypes/pharmacyResponse";
 import {
@@ -55,7 +55,9 @@ function PharmInfoModal({ onClose, selectedPharmInfo }: PharmInfoModalProps) {
         </InfoContent>
       </InfoContaniner>
       <CloseBtnContainer>
-        <CloseBtn onClick={onClose}>닫기</CloseBtn>
+        <CloseBtn onClick={onClose} $btnColor={GRAY_COLOR}>
+          닫기
+        </CloseBtn>
       </CloseBtnContainer>
     </Container>
   );

--- a/front/pages/_app.tsx
+++ b/front/pages/_app.tsx
@@ -56,9 +56,9 @@ function MyApp({ Component, pageProps }: AppProps) {
   useEffect(() => {
     async function getUsers() {
       try {
+        await Api.get<RefreshResponse>("/auth/refresh");
         const { user } = await Api.get<CurrentUserResponse>("/auth/current");
         setUser(user);
-        Api.get<RefreshResponse>("/auth/refresh");
       } catch (err) {}
     }
     getUsers();
@@ -67,9 +67,10 @@ function MyApp({ Component, pageProps }: AppProps) {
   // refresh token이 있을 경우 access token 주기적으로 재발급
   useEffect(() => {
     const timer = setInterval(() => {
-      if (document.hasFocus()) Api.get<RefreshResponse>("/auth/refresh");
+      try {
+        if (document.hasFocus()) Api.get<RefreshResponse>("/auth/refresh");
+      } catch (err) {}
     }, SILENT_REFRESH_TIME);
-
     return () => {
       clearInterval(timer);
     };
@@ -85,16 +86,13 @@ function MyApp({ Component, pageProps }: AppProps) {
               content="minimum-scale=1, initial-scale=1, width=device-width, shrink-to-fit=no, user-scalable=no, viewport-fit=cover"
             />
           </Head>
-
           {!URL_WITHOUT_HEADER.includes(router.pathname) && <Header />}
           <Component {...pageProps} />
           {!URL_WITHOUT_HEADER.includes(router.pathname) && <Footer />}
-
           <ReactQueryDevtools initialIsOpen={false} position="bottom-right" />
         </Hydrate>
       </QueryClientProvider>
     </StyletronProvider>
   );
 }
-
 export default MyApp;

--- a/front/pages/_app.tsx
+++ b/front/pages/_app.tsx
@@ -66,11 +66,14 @@ function MyApp({ Component, pageProps }: AppProps) {
 
   // refresh token이 있을 경우 access token 주기적으로 재발급
   useEffect(() => {
-    const timer = setInterval(() => {
+    const timer = setInterval(async () => {
       try {
-        if (document.hasFocus()) Api.get<RefreshResponse>("/auth/refresh");
+        if (document.hasFocus()) {
+          await Api.get<RefreshResponse>("/auth/refresh");
+        }
       } catch (err) {}
     }, SILENT_REFRESH_TIME);
+
     return () => {
       clearInterval(timer);
     };


### PR DESCRIPTION
## [220826] gray color 추가, refresh api 에러 이슈 해결
- merge 요청자: @rnrn99 
- issue (링크)

## 1. PR 목적
- gray color 추가, refresh api 에러 이슈 해결   


## 2. PR 내용
- gray color(#a4a4a4) 추가, 사용하던 부분을 모두 props로 변경
- refresh api 에러 처리를 안 해서 생기는 문제 해결, 새로고침 시 refresh 후 current user 가져오도록 수정