### PR TITLE
[Front] refactoring

### DIFF
--- a/front/common/header/Header.style.ts
+++ b/front/common/header/Header.style.ts
@@ -3,6 +3,7 @@ import { styled } from "styletron-react";
 export const HeaderContainer = styled(
   "header",
   (props: { $height: string; $bgColor: string }) => ({
+    position: "fixed",
     width: "100vw",
     minHeight: props.$height,
     backgroundColor: props.$bgColor,
@@ -42,3 +43,11 @@ export const Button = styled("button", {
   width: "100%",
   height: "100%",
 });
+
+export const HeaderEmptyBox = styled(
+  "header",
+  (props: { $height: string }) => ({
+    width: "100vw",
+    minHeight: props.$height,
+  }),
+);

--- a/front/common/header/Header.style.ts
+++ b/front/common/header/Header.style.ts
@@ -3,7 +3,6 @@ import { styled } from "styletron-react";
 export const HeaderContainer = styled(
   "header",
   (props: { $height: string; $bgColor: string }) => ({
-    position: "fixed",
     width: "100vw",
     minHeight: props.$height,
     backgroundColor: props.$bgColor,
@@ -14,7 +13,7 @@ export const HeaderContainer = styled(
     gridTemplateColumns: "1fr 1fr 1fr",
     justifyItems: "start",
     alignItems: "center",
-    zIndex: "1",
+    zIndex: 3,
   }),
 );
 
@@ -29,7 +28,7 @@ export const ImageWrapper = styled("div", {
 export const HamburgerBtn = styled("button", {
   fontSize: "2rem",
   color: "#fff",
-  zIndex: "1",
+  zIndex: 3,
 });
 
 export const BellBtn = styled("button", {
@@ -43,11 +42,3 @@ export const Button = styled("button", {
   width: "100%",
   height: "100%",
 });
-
-export const HeaderEmptyBox = styled(
-  "header",
-  (props: { $height: string }) => ({
-    width: "100vw",
-    height: props.$height,
-  }),
-);

--- a/front/common/header/Header.tsx
+++ b/front/common/header/Header.tsx
@@ -1,9 +1,10 @@
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
 import Image from "next/image";
 import { useRouter } from "next/router";
 import { HEADER_HEIGHT, MAIN_COLOR, ROUTE } from "@utils/constant";
 import { BsFillBellFill, BsJustify } from "react-icons/bs";
 import {
+  HeaderEmptyBox,
   HeaderContainer,
   HamburgerBtn,
   ImageWrapper,
@@ -14,14 +15,27 @@ import Sidebar from "@sidebar/Sidebar";
 
 function Header() {
   const router = useRouter();
+  const headerRef = useRef<HTMLDivElement>(null);
+
   const [openSideBar, setOpenSideBar] = useState(false);
+  const [headerHeight, setHeaderHeight] = useState("");
 
   const closeSideBar = () => {
     setOpenSideBar(false);
   };
+
+  useEffect(() => {
+    if (headerRef.current) {
+      setHeaderHeight(headerRef.current.offsetHeight + "px");
+    }
+  }, [headerRef]);
+
   return (
     <>
-      <HeaderContainer $height={HEADER_HEIGHT} $bgColor={MAIN_COLOR}>
+      <HeaderContainer
+        ref={headerRef}
+        $height={HEADER_HEIGHT}
+        $bgColor={MAIN_COLOR}>
         <HamburgerBtn onClick={() => setOpenSideBar(true)}>
           <BsJustify />
         </HamburgerBtn>
@@ -42,6 +56,7 @@ function Header() {
           <BsFillBellFill />
         </BellBtn>
       </HeaderContainer>
+      <HeaderEmptyBox $height={headerHeight} />
       <Sidebar openSideBar={openSideBar} closeSideBar={closeSideBar} />
     </>
   );

--- a/front/common/header/Header.tsx
+++ b/front/common/header/Header.tsx
@@ -26,7 +26,7 @@ function Header() {
 
   useEffect(() => {
     if (headerRef.current) {
-      setHeaderHeight(headerRef.current.offsetHeight + "px");
+      setHeaderHeight(headerRef.current.clientHeight + "px");
     }
   }, [headerRef]);
 

--- a/front/common/header/Header.tsx
+++ b/front/common/header/Header.tsx
@@ -4,7 +4,6 @@ import { useRouter } from "next/router";
 import { HEADER_HEIGHT, MAIN_COLOR, ROUTE } from "@utils/constant";
 import { BsFillBellFill, BsJustify } from "react-icons/bs";
 import {
-  HeaderEmptyBox,
   HeaderContainer,
   HamburgerBtn,
   ImageWrapper,
@@ -43,7 +42,6 @@ function Header() {
           <BsFillBellFill />
         </BellBtn>
       </HeaderContainer>
-      <HeaderEmptyBox $height={HEADER_HEIGHT} />
       <Sidebar openSideBar={openSideBar} closeSideBar={closeSideBar} />
     </>
   );

--- a/front/common/modal/Modal.style.ts
+++ b/front/common/modal/Modal.style.ts
@@ -13,24 +13,27 @@ export const Background = styled("div", (props: { $isOpen: boolean }) => ({
   transition: "visibility 0.15s ease-out",
 }));
 
-export const ModalContainer = styled("div", (props: { $isOpen: boolean }) => ({
-  position: "fixed",
-  width: "85vw",
-  top: "50%",
-  left: "50%",
-  transform: "translate(-50%, -50%)",
-  backgroundColor: "#fff",
-  zIndex: 3,
-  visibility: props.$isOpen ? "visible" : "hidden",
-  transition: "visibility 0.15s ease-out",
-  animationDuration: "0.2s",
-  animationTimingFunction: "ease-out",
-  animationName: {
-    from: {
-      opacity: 0,
+export const ModalContainer = styled(
+  "div",
+  (props: { $isOpen: boolean; $isInfoPage?: boolean }) => ({
+    position: "fixed",
+    width: props.$isInfoPage ? "60vw" : "85vw",
+    top: "50%",
+    left: "50%",
+    transform: "translate(-50%, -50%)",
+    backgroundColor: "#fff",
+    zIndex: 3,
+    visibility: props.$isOpen ? "visible" : "hidden",
+    transition: "visibility 0.15s ease-out",
+    animationDuration: "0.2s",
+    animationTimingFunction: "ease-out",
+    animationName: {
+      from: {
+        opacity: 0,
+      },
+      to: {
+        opacity: 1,
+      },
     },
-    to: {
-      opacity: 1,
-    },
-  },
-}));
+  }),
+);

--- a/front/common/modal/Modal.tsx
+++ b/front/common/modal/Modal.tsx
@@ -3,16 +3,19 @@ import { Background, ModalContainer } from "./Modal.style";
 interface ModalProps {
   children: React.ReactNode;
   open: boolean;
+  isInfoPage?: boolean;
   onClose: () => void;
 }
 
-function Modal({ children, open, onClose }: ModalProps) {
+function Modal({ children, open, onClose, isInfoPage }: ModalProps) {
   if (!open) return null;
 
   return (
     <>
       <Background $isOpen={open} onClick={onClose} />
-      <ModalContainer $isOpen={open}>{children}</ModalContainer>
+      <ModalContainer $isOpen={open} $isInfoPage={isInfoPage}>
+        {children}
+      </ModalContainer>
     </>
   );
 }

--- a/front/common/userContainer/Container.style.ts
+++ b/front/common/userContainer/Container.style.ts
@@ -4,7 +4,7 @@ export const MainContainer = styled(
   "div",
   (props: { $bgColor: string; $fullHeight: string }) => ({
     width: "100vw",
-    height: `calc(${props.$fullHeight})`,
+    minHeight: `calc(${props.$fullHeight})`,
     display: "grid",
     gridTemplateRows: "1fr 3fr 5fr",
     backgroundColor: props.$bgColor,

--- a/front/components/account/findEmail/AuthForm.tsx
+++ b/front/components/account/findEmail/AuthForm.tsx
@@ -16,6 +16,7 @@ import {
   CloseBtnContainer,
   CloseBtn,
 } from "./AuthForm.style";
+import { toast } from "react-toastify";
 
 interface AuthFormProps {
   onClose: () => void;
@@ -49,8 +50,8 @@ function AuthForm({ onClose, phone }: AuthFormProps) {
           query: { userId: user.id },
         });
       },
-      onError: (err) => {
-        console.log(err);
+      onError: ({ message }) => {
+        toast.error(message);
         setIsSubmitted(false);
       },
     },

--- a/front/components/account/findEmail/AuthForm.tsx
+++ b/front/components/account/findEmail/AuthForm.tsx
@@ -22,7 +22,7 @@ interface AuthFormProps {
   phone: string;
 }
 
-const verifyCode = async (phone: string, code: string) => {
+const sendToVerifyCode = async (phone: string, code: string) => {
   const res = await fetch("/api/verify-code", {
     method: "POST",
     body: JSON.stringify({ phone, code }),
@@ -37,20 +37,24 @@ function AuthForm({ onClose, phone }: AuthFormProps) {
   const [code, setCode] = useState("");
   const [isSubmitted, setIsSubmitted] = useState(false);
 
-  useQuery(findEmailKeys.verifyCode(code), () => verifyCode(phone, code), {
-    enabled: !!code && isSubmitted,
-    retry: false,
-    onSuccess: ({ user }) => {
-      router.push({
-        pathname: ROUTE.EMAIL_RESULT,
-        query: { userId: user.id },
-      });
+  useQuery(
+    findEmailKeys.verifyCode(code),
+    () => sendToVerifyCode(phone, code),
+    {
+      enabled: !!code && isSubmitted,
+      retry: false,
+      onSuccess: ({ user }) => {
+        router.push({
+          pathname: ROUTE.EMAIL_RESULT,
+          query: { userId: user.id },
+        });
+      },
+      onError: (err) => {
+        console.log(err);
+        setIsSubmitted(false);
+      },
     },
-    onError: (err) => {
-      console.log(err);
-      setIsSubmitted(false);
-    },
-  });
+  );
 
   return (
     <FormContainer>

--- a/front/components/account/findEmail/FindEmailForm.tsx
+++ b/front/components/account/findEmail/FindEmailForm.tsx
@@ -30,6 +30,7 @@ import {
 } from "./FindEmailForm.style";
 import Modal from "@modal/Modal";
 import AuthForm from "./AuthForm";
+import { toast } from "react-toastify";
 
 interface FindEmailValues {
   name: string;
@@ -60,8 +61,8 @@ function FindEmailForm() {
       onSuccess: () => {
         setAuthModalOpen(true);
       },
-      onError: (err) => {
-        console.log(err);
+      onError: ({ message }) => {
+        toast.error(message);
       },
     },
   );

--- a/front/components/login/LoginForm.tsx
+++ b/front/components/login/LoginForm.tsx
@@ -53,8 +53,6 @@ function LoginForm() {
   const [, setUser] = useAtom(userAtom);
   const [isAutoLoginChecked, setIsAutoLoginChecked] = useState(false);
 
-  const notifyLoginFail = () => toast.error(TOASTIFY.LOGIN_FAIL);
-
   const initialValue: LoginFormValues = {
     email: userEmail,
     password: "",
@@ -72,8 +70,8 @@ function LoginForm() {
         setUser(user);
         router.push(ROUTE.MAIN);
       },
-      onError: () => {
-        notifyLoginFail();
+      onError: ({ message }) => {
+        toast.error(message);
       },
     },
   );

--- a/front/components/login/LoginForm.tsx
+++ b/front/components/login/LoginForm.tsx
@@ -53,7 +53,7 @@ function LoginForm() {
   const [, setUser] = useAtom(userAtom);
   const [isAutoLoginChecked, setIsAutoLoginChecked] = useState(false);
 
-  const nofityLoginFail = () => toast.error(TOASTIFY.LOGIN_FAIL);
+  const notifyLoginFail = () => toast.error(TOASTIFY.LOGIN_FAIL);
 
   const initialValue: LoginFormValues = {
     email: userEmail,
@@ -72,9 +72,8 @@ function LoginForm() {
         setUser(user);
         router.push(ROUTE.MAIN);
       },
-      onError: ({ message }) => {
-        console.log(message);
-        nofityLoginFail();
+      onError: () => {
+        notifyLoginFail();
       },
     },
   );

--- a/front/components/messages/CheckModal.tsx
+++ b/front/components/messages/CheckModal.tsx
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from "react-query";
 import * as Api from "@api";
 import { messageKeys } from "@utils/queryKey";
-import { GRAY_COLOR, ACCENT_COLOR } from "@utils/constant";
+import { GRAY_COLOR, ACCENT_COLOR, TOASTIFY } from "@utils/constant";
 import {
   CheckModalContainer,
   CloseBtn,
@@ -10,6 +10,7 @@ import {
   CheckModalBtn,
 } from "./MessagesPage.style";
 import { MessageValues } from "./Messages";
+import { toast } from "react-toastify";
 
 interface CheckModalProps {
   selectedMessage: MessageValues;
@@ -25,8 +26,8 @@ function CheckModal({ selectedMessage, pageCount, onClose }: CheckModalProps) {
       queryClient.invalidateQueries(messageKeys.getMessages(pageCount));
       onClose();
     },
-    onError: (err) => {
-      console.log(err);
+    onError: () => {
+      toast.error(TOASTIFY.FAIL);
     },
   });
 

--- a/front/components/search/pharmacy/SearchPharmPage.style.ts
+++ b/front/components/search/pharmacy/SearchPharmPage.style.ts
@@ -9,6 +9,7 @@ export const PageContainer = styled(
   }) => ({
     width: "100vw",
     display: "grid",
+    height: `calc(${props.$fullHeight} - (${props.$headerHeight} + ${props.$footerHeight}))`,
     minHeight: `calc(${props.$fullHeight} - (${props.$headerHeight} + ${props.$footerHeight}))`,
     gridTemplateRows: "1.2fr 1fr",
   }),
@@ -49,6 +50,7 @@ export const SearchOption = styled("option", {
 
 export const SearchInput = styled("input", {
   width: "90%",
+  height: "2.3rem",
   justifySelf: "center",
   paddingLeft: "1rem",
   borderRadius: "15px",

--- a/front/components/search/pharmacy/SearchPharmPage.style.ts
+++ b/front/components/search/pharmacy/SearchPharmPage.style.ts
@@ -9,7 +9,6 @@ export const PageContainer = styled(
   }) => ({
     width: "100vw",
     display: "grid",
-    height: `calc(${props.$fullHeight} - (${props.$headerHeight} + ${props.$footerHeight}))`,
     minHeight: `calc(${props.$fullHeight} - (${props.$headerHeight} + ${props.$footerHeight}))`,
     gridTemplateRows: "1.2fr 1fr",
   }),
@@ -33,6 +32,7 @@ export const SearchContainer = styled("form", {
   gridTemplateColumns: "1fr 4fr 1fr",
   justifySelf: "center",
   alignSelf: "end",
+  margin: "0.3rem 0",
 });
 
 export const SearchSelect = styled("select", (props: { $bgColor: string }) => ({

--- a/front/components/search/pharmacy/SearchPharmPage.style.ts
+++ b/front/components/search/pharmacy/SearchPharmPage.style.ts
@@ -7,9 +7,10 @@ export const PageContainer = styled(
     $footerHeight: string;
     $fullHeight: string;
   }) => ({
+    position: "relative",
     width: "100vw",
-    display: "grid",
     minHeight: `calc(${props.$fullHeight} - (${props.$headerHeight} + ${props.$footerHeight}))`,
+    display: "grid",
     gridTemplateRows: "1.2fr 1fr",
   }),
 );
@@ -41,6 +42,7 @@ export const SearchSelect = styled("select", (props: { $bgColor: string }) => ({
   borderRadius: "15px",
   padding: "0 0.3rem",
   textAlign: "center",
+  height: "2.3rem",
 }));
 
 export const SearchOption = styled("option", {
@@ -61,6 +63,7 @@ export const SearchBtn = styled("button", (props: { $bgColor: string }) => ({
   color: "#fff",
   borderRadius: "15px",
   padding: "0 0.3rem",
+  height: "2.3rem",
 }));
 
 export const Map = styled("div", {

--- a/front/pages/info/index.tsx
+++ b/front/pages/info/index.tsx
@@ -67,6 +67,7 @@ const InfoPage: NextPage = () => {
       {(isInstallModalOpen || isInfoModalOpen || isTeamModalOpen) && (
         <Modal
           open={isInstallModalOpen || isInfoModalOpen || isTeamModalOpen}
+          isInfoPage
           onClose={modalCloseHandler}>
           {(isInstallModalOpen && (
             <InstallModal onClose={() => setIsInstallModalOpen(false)} />

--- a/front/pages/messages/index.tsx
+++ b/front/pages/messages/index.tsx
@@ -6,7 +6,7 @@ import { useQuery, useMutation, useQueryClient } from "react-query";
 import * as Api from "@api";
 import { CommonResponseDto as CommonResponse } from "@modelTypes/commonResponseDto";
 import { messageKeys } from "@utils/queryKey";
-import { MAIN_COLOR, ACCENT_COLOR, ROUTE } from "@utils/constant";
+import { MAIN_COLOR, ACCENT_COLOR, ROUTE, TOASTIFY } from "@utils/constant";
 
 import {
   ContentContainer,
@@ -24,6 +24,7 @@ import Container from "@container/Container";
 import Modal from "@modal/Modal";
 import CheckModal from "@messagesComp/CheckModal";
 import Messages, { MessageValues } from "@messagesComp/Messages";
+import { toast } from "react-toastify";
 
 interface MessageResponse extends CommonResponse {
   alarms: MessageValues[];
@@ -94,8 +95,8 @@ const MessageListPage: NextPage = () => {
         // 삭제 성공 후 알림 목록 갱신
         queryClient.invalidateQueries(messageKeys.getMessages(pageCount));
       },
-      onError: (err) => {
-        console.log(err);
+      onError: () => {
+        toast.error(TOASTIFY.FAIL);
       },
     },
   );

--- a/front/pages/messages/setting/[id].tsx
+++ b/front/pages/messages/setting/[id].tsx
@@ -39,7 +39,13 @@ import RemindForm from "@messagesComp/setting/RemindForm";
 
 interface SetNotificationPageProps {
   bookmarkId: string;
-  setting: GetAlarmValues;
+  setting: {
+    minute: number;
+    hour: number;
+    vip: number[];
+    repeatTime: number;
+    pillName: string;
+  };
 }
 
 const SetNotificationPage: NextPage<SetNotificationPageProps> = ({
@@ -50,18 +56,10 @@ const SetNotificationPage: NextPage<SetNotificationPageProps> = ({
   const router = useRouter();
 
   const [isNotificationToggle, setIsNotificationToggle] = useState(true);
-  const [isRemindToggle, setIsRemindToggle] = useState(
-    typeof setting.repeatTime === "number" && setting.repeatTime > 0,
-  );
-  const [isAfternoon, setIsAfternoon] = useState(
-    typeof setting.hour === "number" && setting.hour >= 12,
-  );
-  const [vip, setVip] = useState<number[]>(
-    typeof setting.vip === "object" ? setting.vip : [],
-  );
-  const [pillName, setPillName] = useState(
-    typeof setting.pillName === "string" ? setting.pillName : "",
-  );
+  const [isRemindToggle, setIsRemindToggle] = useState(setting.repeatTime > 0);
+  const [isAfternoon, setIsAfternoon] = useState(setting.hour >= 12);
+  const [vip, setVip] = useState<number[]>(setting.vip);
+  const [pillName, setPillName] = useState(setting.pillName);
   const [deviceToken, setDeviceToken] = useState("");
 
   const setAlarmMutation = useMutation(
@@ -92,9 +90,9 @@ const SetNotificationPage: NextPage<SetNotificationPageProps> = ({
   );
 
   const initialValue: SettingFormValues = {
-    hour: typeof setting.hour === "number" ? setting.hour : 0,
-    minute: typeof setting.minute === "number" ? setting.minute : 0,
-    repeatTime: typeof setting.repeatTime === "number" ? setting.repeatTime : 0,
+    hour: setting.hour,
+    minute: setting.minute,
+    repeatTime: setting.repeatTime,
   };
 
   const formik = useFormik({
@@ -206,12 +204,18 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     };
   }
 
-  const result: GetAlarmResponse = await res.json();
+  const { alarm }: GetAlarmResponse = await res.json();
 
   return {
     props: {
       bookmarkId,
-      setting: result.alarm,
+      setting: {
+        minute: typeof alarm.minute === "number" ? alarm.minute : 0,
+        hour: typeof alarm.hour === "number" ? alarm.hour : 0,
+        vip: typeof alarm.vip === "object" ? alarm.vip : [],
+        repeatTime: typeof alarm.repeatTime === "number" ? alarm.repeatTime : 0,
+        pillName: typeof alarm.pillName === "string" ? alarm.pillName : "",
+      },
     },
   };
 };


### PR DESCRIPTION
## [221009] Front Refactoring
- merge 요청자: @rnrn99 

## 1. PR 목적
- 사소한 리팩토링 


## 2. PR 내용
- `/info`에서 모달 너비 수정(85vw -> 60vw)
   - `/info`외의 페이지에서 모든 모달의 너비는 85vw로 고정임.
   - `/info`에서만 60vw의 값을 줄 예정이라 width를 prop으로 추가하는 대신 infopage에 대한 boolean 값을 optional prop으로 추가함.
- `/messages/setting/[id]`에서 타입 가드 위치 변경
   - 기존: props로 넘어오는 setting의 값을 사용하는 과정에서 타입 가드 사용
   - 변경 후: props로 넘기기 전 setting을 만들며 타입 가드 사용
- console.log(err) 대신 toastify 사용
- `/search/pharmacy`에서 키보드 밀림 이슈 해결
   -  header의 zIndex 값 수정(1 -> 3)
   -  HeaderContainer의 높이에 따라 HeaderEmptyBox height 변경(clientHeight 사용)